### PR TITLE
Add PR labeler and release drafter config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
         run: nix develop -c go fmt ./... || true
       - name: Linter
         run: nix develop -c golangci-lint run || true
+      - name: Build
+        run: nix build
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,13 +21,13 @@ jobs:
           name: cachix-action
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Tests
-        run: nix develop -c go test -v ./...
+        run: nix develop -c go test -v ./... -test.short
       - name: Formatter
         run: nix develop -c go fmt ./... || true
       - name: Linter
         run: nix develop -c golangci-lint run || true
       - name: Build
-        run: nix build
+        run: nix develop -c go build
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4.14.1
         with:

--- a/.github/workflows/config/pr-labeler.yml
+++ b/.github/workflows/config/pr-labeler.yml
@@ -1,0 +1,7 @@
+enhancement: ['enhancement/*', 'feature/*']
+breaking-change: ['breaking/*', 'break/*']
+documentation: ['docs/*', 'doc/*']
+bug: ['bug/*', 'fix/*']
+tests: ['test/*', 'tests/*']
+dependency-update: ['dep/*', 'dependency/*', 'dependency-update/*']
+snyk: ['update/*']

--- a/.github/workflows/config/release-drafter.yml
+++ b/.github/workflows/config/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch  
+exclude-labels:
+  - 'auto-update'
+  - 'auto-documentation'
+  - 'auto-changelog'
+  # - 'release'
+categories:
+  - title: 'Breaking changes'
+    label: 'breaking-change'
+  - title: 'Features'
+    label: 'enhancement'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Bug Fixes'
+    labels: 'bug'
+  - title: 'Dependency updates'
+    labels:
+      - 'dependency-update'
+      - 'snyk'
+template: |
+  # Changes
+  $CHANGES

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/workflows/config/pr-labeler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Draft a release
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:      
+      - name: Update release draft
+        id: draft
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: workflows/config/release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
           name: cachix-action
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: Tests
-        run: nix develop -c go test -v ./...
+        run: nix develop -c go test -v ./... -test.short
       - name: Formatter
         run: nix develop -c go fmt ./...
       - name: Linter
         run: nix develop -c golangci-lint run || true
       - name: Build
-        run: nix develop -c go build
+        run: nix develop -c 'go build && gzip ./conntest'
       - name: Create Release
         uses: actions/create-release@v1
         env:
@@ -35,4 +35,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["./conntest"]'
+          asset_paths: '["./conntest", "conntest.gz"]'

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestTagsVar(t *testing.T) {
+	str := "lorem=ipsum;dolor=sit-amet"
+	tags := tagsVar{}
+	tags.Set(str)
+
+	if tags.String() != str {
+		t.Fail()
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
               pname = "conntest";
               version = self.shortRev or "${self.lastModifiedDate}-dirty";
               src = self;
-              vendorSha256 = "";
+              vendorSha256 = "gfYzoditeKWwguNhBtCt3g4yB53LsAxFQhuPbZABYHE=";
             };
           }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
             devShell = import ./shell.nix { inherit pkgs; };
             defaultPackage = pkgs.buildGoModule {
               pname = "conntest";
-              version = "0.1.0";
+              version = self.shortRev or "${self.lastModifiedDate}-dirty";
               src = self;
               vendorSha256 = "";
             };

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {}}:
 let
 
-  inherit (pkgs) go golangci-lint gopls gore gotools go-tools usql cobra-cli;
+  inherit (pkgs) go golangci-lint gopls gore gotools go-tools usql cobra-cli gzip;
 in pkgs.mkShell {
-  buildInputs = [ go golangci-lint gopls gore gotools go-tools usql cobra-cli];
+  buildInputs = [ go golangci-lint gopls gore gotools go-tools usql cobra-cli gzip];
 }


### PR DESCRIPTION
Previously we set release information manually. Now PRs are categorized
and added in their respective sections depending on branch name
they originated from.

For more details on how we categorize, see PR-labeler configuration:
[pr-labeler.yaml](./.github/workflows/config/pr-labeler.yaml)